### PR TITLE
replace T::BlockNumber with BlockNumberFor<T>

### DIFF
--- a/content/md/en/docs/tutorials/build-application-logic/use-macros-in-a-custom-pallet.md
+++ b/content/md/en/docs/tutorials/build-application-logic/use-macros-in-a-custom-pallet.md
@@ -238,7 +238,7 @@ To implement storage for the proof-of-existence pallet:
 
    ```rust
    #[pallet::storage]
-   pub(super) type Claims<T: Config> = StorageMap<_, Blake2_128Concat, T::Hash, (T::AccountId, T::BlockNumber)>;
+   pub(super) type Claims<T: Config> = StorageMap<_, Blake2_128Concat, T::Hash, (T::AccountId, BlockNumberFor<T>)>;
    ```
 
 1. Save your changes.


### PR DESCRIPTION
It will cause error because associated type `BlockNumber` not found for `T`